### PR TITLE
Bytecode instead of assembly

### DIFF
--- a/node/pvm/compiler.py
+++ b/node/pvm/compiler.py
@@ -26,164 +26,164 @@ def compile(tree):
 
     if not check_tree(tree):
         if tree[0] == 'NUMBER' or tree[0] == 'STRING':
-            code += f'1101{encode(tree[1])}'
+            code += f'1101{encode(tree[1])};'
             return
         elif tree[0] == 'LITERAL':
-            code += f'1102{encode(tree[1])}'
+            code += f'1102{encode(tree[1])};'
             return
 
     key = get_key(tree)
     val = tree[key]
 
     if key[0] == 'INT':
-        code += f'1301{encode(val[1])}'
+        code += f'1301{encode(val[1])};'
     elif key[0] == 'STR':
-        code += f'1302{encode(val[1])}'
+        code += f'1302{encode(val[1])};'
 
     elif key[0] == 'SET':
         if check_tree(val[1]):
             compile(val[1])
-            code += f'14{encode(val[0][1])}'
+            code += f'14{encode(val[0][1])};'
         else:
             if val[1][0] == 'LITERAL':
-                code += f'1102{encode(val[1][1])}'
+                code += f'1102{encode(val[1][1])};'
             else:
-                code += f'1101{encode(val[1][1])}'
-            code += f'14{encode(val[0][1])}'
+                code += f'1101{encode(val[1][1])};'
+            code += f'14{encode(val[0][1])};'
 
     elif key[0] in ['OR', 'AND']:
         if check_tree(val[0]):
             compile(val[0])
         else:
             if val[0][0] == 'LITERAL':
-                code += f'1102{encode(val[0][1])}'
+                code += f'1102{encode(val[0][1])};'
             else:
-                code += f'1101{encode(val[0][1])}'
+                code += f'1101{encode(val[0][1])};'
 
         if check_tree(val[1]):
             compile(val[1])
         else:
             if val[1][0] == 'LITERAL':
-                code += f'1102{encode(val[1][1])}'
+                code += f'1102{encode(val[1][1])};'
             else:
-                code += f'1101{encode(val[1][1])}'
+                code += f'1101{encode(val[1][1])};'
 
         if key[0] == 'OR':
-            code += '20'
+            code += '20;'
         elif key[0] == 'AND':
-            code += '21'
+            code += '21;'
 
     elif key[0] in ['PLUS', 'MINUS', 'MULT', 'DIV', 'MOD']:
         if check_tree(val[1]):
             compile(val[1])
         else:
             if val[1][0] == 'LITERAL':
-                code += f'1102{encode(val[1][1])}'
+                code += f'1102{encode(val[1][1])};'
             else:
-                code += f'1101{encode(val[1][1])}'
+                code += f'1101{encode(val[1][1])};'
 
         if check_tree(val[0]):
             compile(val[0])
         else:
             if val[0][0] == 'LITERAL':
-                code += f'1102{encode(val[0][1])}'
+                code += f'1102{encode(val[0][1])};'
             else:
-                code += f'1101{encode(val[0][1])}'
+                code += f'1101{encode(val[0][1])};'
 
         if key[0] == 'PLUS':
-            code += '15'
+            code += '15;'
         elif key[0] == 'MINUS':
-            code += '16'
+            code += '16;'
         elif key[0] == 'MULT':
-            code += '17'
+            code += '17;'
         elif key[0] == 'DIV':
-            code += '18'
+            code += '18;'
         elif key[0] == 'MOD':
-            code += '19'
+            code += '19;'
 
     elif key[0] in ['EQUAL', 'NOT_EQUAL', 'LOWER', 'GREATER', 'LOWER_OR_EQUAL', 'GREATER_OR_EQUAL']:
         if check_tree(val[1]):
             compile(val[1])
         else:
             if val[1][0] == 'LITERAL':
-                code += f'1102{encode(val[1][1])}'
+                code += f'1102{encode(val[1][1])};'
             else:
-                code += f'1101{encode(val[1][1])}'
+                code += f'1101{encode(val[1][1])};'
 
         if check_tree(val[0]):
             compile(val[0])
         else:
             if val[0][0] == 'LITERAL':
-                code += f'1102{encode(val[0][1])}'
+                code += f'1102{encode(val[0][1])};'
             else:
-                code += f'1101{encode(val[0][1])}'
+                code += f'1101{encode(val[0][1])};'
 
         if key[0] == 'EQUAL':
-            code += '1a'
+            code += '1a;'
         elif key[0] == 'NOT_EQUAL':
-            code += '1b'
+            code += '1b;'
         elif key[0] == 'LOWER':
-            code += '1c'
+            code += '1c;'
         elif key[0] == 'GREATER':
-            code += '1d'
+            code += '1d;'
         elif key[0] == 'LOWER_OR_EQUAL':
-            code += '1e'
+            code += '1e;'
         elif key[0] == 'GREATER_OR_EQUAL':
-            code += '1f'
+            code += '1f;'
 
     elif key[0] == 'RETURN':
         if check_tree(val):
             compile(val)
         else:
             if val[1][0] == 'LITERAL':
-                code += f'1102{encode(val[1][1])}'
+                code += f'1102{encode(val[1][1])};'
             else:
-                code += f'1101{encode(val[1][1])}'
-        code += '25'
+                code += f'1101{encode(val[1][1])};'
+        code += '25;'
 
     elif key[0] == 'IF':
         if check_tree(val[0]):
             compile(val[0])
         else:
             if val[0][0] == 'LITERAL':
-                code += f'1102{encode(val[0][1])}'
+                code += f'1102{encode(val[0][1])};'
             else:
-                code += f'1101{encode(val[0][1])}'
+                code += f'1101{encode(val[0][1])};'
 
         ln = len(jump_lines)
-        code += f'24[{ln}]'
+        code += f'24[{ln}];'
         jump_lines[ln] = -1
 
         for tr in val[1]:
             if check_tree(tr):
                 compile(tr)
             else:
-                code += f'11{encode(tr[1])}'
-        jump_lines[ln] = len(code)
+                code += f'11{encode(tr[1])};'
+        jump_lines[ln] = code.count(';')
 
     elif key[0] == 'WHILE':
-        after_jmp = len(code)
+        after_jmp = code.count(';')
 
         if check_tree(val[0]):
             compile(val[0])
         else:
             if val[0][0] == 'LITERAL':
-                code += f'1102{encode(val[0][1])}'
+                code += f'1102{encode(val[0][1])};'
             else:
-                code += f'1101{encode(val[0][1])}'
+                code += f'1101{encode(val[0][1])};'
 
         ln = len(jump_lines)
-        code += f'24[{ln}]'
+        code += f'24[{ln}];'
         jump_lines[ln] = -1
 
         for tr in val[1]:
             if check_tree(tr):
                 compile(tr)
             else:
-                code += f'11{encode(tr[1])}'
+                code += f'11{encode(tr[1])};'
 
-        code += f'23{encode(after_jmp)}'
-        jump_lines[ln] = len(code)
+        code += f'23{encode(after_jmp)};'
+        jump_lines[ln] = code.count(';')
 
 
 with open(argv[1], 'r') as f:
@@ -192,9 +192,11 @@ with open(argv[1], 'r') as f:
 tokens = lex(code)
 tree = parse(tokens)
 jump_lines = {}
-code = '10010'
+code = '10010;'
 for line in tree:
     compile(line)
+
+code = code.replace(';', '')
 
 for k, v in jump_lines.items():
     code = code.replace(f'[{k}]', encode(v), 1)

--- a/node/pvm/compiler.py
+++ b/node/pvm/compiler.py
@@ -12,136 +12,144 @@ def check_tree(tree):
     return type(tree) == type({}) or type(tree) == type([])
 
 
+def encode(value):
+    if type(value) == type(0) or [1 for c in value if c in '0123456789']:
+        ret = hex(int(value))[2:]
+    else:
+        ret = ''.join('{:02x}'.format(ord(c)) for c in value)
+    return hex(len(ret))[2:] + ret
+
+
 def compile(tree):
     global code
 
     if not check_tree(tree):
         if tree[0] in ['LITERAL', 'NUMBER', 'STRING']:
-            code += f'push {tree[1]};\n'
+            code += f'11{encode(tree[1])}'
             return
 
     key = get_key(tree)
     val = tree[key]
 
     if key[0] == 'INT':
-        code += f'var int, {val[1]};\n'
+        code += f'1301{encode(val[1])}'
     elif key[0] == 'STR':
-        code += f'var str, {val[1]};\n'
+        code += f'1302{encode(val[1])}'
 
     elif key[0] == 'SET':
         if check_tree(val[1]):
             compile(val[1])
-            code += f'set {val[0][1]};\n'
+            code += f'14{encode(val[0][1])}'
         else:
-            code += f'push {val[1][1]};\n'
-            code += f'set {val[0][1]};\n'
+            code += f'11{encode(val[1][1])}'
+            code += f'14{encode(val[0][1])}'
 
     elif key[0] in ['OR', 'AND']:
         if check_tree(val[0]):
             compile(val[0])
         else:
-            code += f'push {val[0][1]};\n'
+            code += f'11{encode(val[0][1])}'
 
         if check_tree(val[1]):
             compile(val[1])
         else:
-            code += f'push {val[1][1]};\n'
+            code += f'11{encode(val[1][1])}'
 
         if key[0] == 'OR':
-            code += 'or;\n'
+            code += '20'
         elif key[0] == 'AND':
-            code += 'and;\n'
+            code += '21'
 
     elif key[0] in ['PLUS', 'MINUS', 'MULT', 'DIV', 'MOD']:
         if check_tree(val[1]):
             compile(val[1])
         else:
-            code += f'push {val[1][1]};\n'
+            code += f'11{encode(val[1][1])}'
 
         if check_tree(val[0]):
             compile(val[0])
         else:
-            code += f'push {val[0][1]};\n'
+            code += f'11{encode(val[0][1])}'
 
         if key[0] == 'PLUS':
-            code += 'sum;\n'
+            code += '15'
         elif key[0] == 'MINUS':
-            code += 'sub;\n'
+            code += '16'
         elif key[0] == 'MULT':
-            code += 'mul;\n'
+            code += '17'
         elif key[0] == 'DIV':
-            code += 'div;\n'
+            code += '18'
         elif key[0] == 'MOD':
-            code += 'mod;\n'
+            code += '19'
 
     elif key[0] in ['EQUAL', 'NOT_EQUAL', 'LOWER', 'GREATER', 'LOWER_OR_EQUAL', 'GREATER_OR_EQUAL']:
         if check_tree(val[1]):
             compile(val[1])
         else:
-            code += f'push {val[1][1]};\n'
+            code += f'11{encode(val[1][1])}'
 
         if check_tree(val[0]):
             compile(val[0])
         else:
-            code += f'push {val[0][1]};\n'
+            code += f'11{encode(val[0][1])}'
 
         if key[0] == 'EQUAL':
-            code += 'eq;\n'
+            code += '1a'
         elif key[0] == 'NOT_EQUAL':
-            code += 'eq;\nrev;\n'
+            code += '1b'
         elif key[0] == 'LOWER':
-            code += 'lt;\n'
+            code += '1c'
         elif key[0] == 'GREATER':
-            code += 'gt;\n'
+            code += '1d'
         elif key[0] == 'LOWER_OR_EQUAL':
-            code += 'lte;\n'
+            code += '1e'
         elif key[0] == 'GREATER_OR_EQUAL':
-            code += 'gte;\n'
+            code += '1f'
 
     elif key[0] == 'RETURN':
         if check_tree(val):
             compile(val)
         else:
-            code += f'push {val[1]};\n'
-        code += 'stop;\n'
+            code += f'11{encode(val[1])}'
+        code += '25'
 
     elif key[0] == 'IF':
         if check_tree(val[0]):
             compile(val[0])
         else:
-            code += f'push {val[0][1]};\n'
+            code += f'11{encode(val[0][1])}'
 
         ln = len(jump_lines)
-        code += f'rev;\njmpif [{ln}];\n'
+        code += f'24[{ln}]'
         jump_lines[ln] = -1
 
         for tr in val[1]:
             if check_tree(tr):
                 compile(tr)
             else:
-                code += f'push {tr[1]};\n'
-        jump_lines[ln] = str(code.count(';'))
+                code += f'11{encode(tr[1])}'
+        jump_lines[ln] = len(code)
 
     elif key[0] == 'WHILE':
-        after_jmp = str(code.count(';'))
+        after_jmp = len(code)
 
         if check_tree(val[0]):
             compile(val[0])
         else:
-            code += f'push {val[0][1]};\n'
+            code += f'11{encode(val[0][1])}'
 
         ln = len(jump_lines)
-        code += f'rev;\njmpif [{ln}];\n'
+        code += f'24[{ln}]'
         jump_lines[ln] = -1
 
         for tr in val[1]:
             if check_tree(tr):
                 compile(tr)
             else:
-                code += f'push {tr[1]};\n'
+                code += f'11{encode(tr[1])}'
 
-        code += f'jmp {after_jmp};\n'
-        jump_lines[ln] = str(code.count(';'))
+        code += f'23{encode(after_jmp)}'
+        jump_lines[ln] = len(code)
 
 
 with open(argv[1], 'r') as f:
@@ -150,12 +158,12 @@ with open(argv[1], 'r') as f:
 tokens = lex(code)
 tree = parse(tokens)
 jump_lines = {}
-code = 'begin "";\n'
+code = '100'
 for line in tree:
     compile(line)
 
 for k, v in jump_lines.items():
-    code = code.replace(f'[{k}]', str(v), 1)
+    code = code.replace(f'[{k}]', encode(v), 1)
 
 with open(argv[1] + 'a', 'w') as f:
     f.write(code)

--- a/node/pvm/tests/test.py
+++ b/node/pvm/tests/test.py
@@ -34,7 +34,7 @@ for file in files:
     try:
         run_and_wait('python3.9 ../compiler.py ' + file, True)
         output = run_and_wait('node ../vm.js ' + file + 'a', False)
-        stack = json.loads(output)[-len(correct):]
+        stack = json.loads(output)
         if stack == correct:
             passed_tests += 1
             print(COLORS['passed'] + 'Test passed ✔')

--- a/node/pvm/vm.js
+++ b/node/pvm/vm.js
@@ -58,15 +58,12 @@ class VM {
             }
             else if ([17, 19].includes(call[0])) {
                 // 2 args
-                console.log(code.slice(0, 10))
                 call.push(parseInt(code.slice(2, 4), 16))
                 let ln = parseInt(code.slice(4, 6), 16)
                 let s = code.slice(6, 6 + ln)
                 if (call[0] == 19 || call[1] == 2) {
                     // arg is string
-                    console.log(s)
                     let bytes = [...s.matchAll(/[^ ]{1,2}/g)].map(a => parseInt(a[0], 16))
-                    console.log(bytes)
                     call.push(Buffer.from(bytes).toString())
                 }
                 else {
@@ -85,7 +82,6 @@ class VM {
         this.stack = []
         this.calls = calls
         this.index = -1
-        console.log(calls)
         for (let i = 0; i < this.calls.length; i += 1) {
             if (this.calls[i][0] == 16 && this.calls[i][1] == '\x00') {
                 this.index = i + 1
@@ -101,8 +97,6 @@ class VM {
 
     runNextLine () {
         let line = this.calls[this.index]
-
-        console.log(line)
 
         if (line[0] == 17) {
             if (line[1] == 1) this.stack.push(line[2])
@@ -214,11 +208,12 @@ class VM {
             this.index = this.calls.length
         }
 
+        /*
         console.log('Call =>', line)
         console.log('Index =>', this.index)
         console.log('Stack =>', this.stack)
         console.log('Variables =>', this.variables)
-        console.log()
+        console.log()*/
 
         this.index += 1
     }
@@ -233,10 +228,10 @@ class VM {
 const min = Math.min
 const fs = require('fs')
 code = fs.readFileSync(process.argv[2], 'utf8')
-console.time('prepare')
+//console.time('prepare')
 vm = new VM(code.toString())
-console.timeEnd('prepare')
-console.time('run')
+//console.timeEnd('prepare')
+//console.time('run')
 vm.run()
-console.timeEnd('run')
+//console.timeEnd('run')
 if (process.argv.length <= 3) console.dir(vm.stack, {'maxArrayLength': null})

--- a/node/pvm/vm.js
+++ b/node/pvm/vm.js
@@ -1,27 +1,36 @@
 class VM {
     /*
 
-    begin "name"       => Begin of function
-    push value         => Push value to stack
-    pop                => Pop value from stack
-    var type, "name"   => Declare variable
-    set "name"         => Set value to variable
-    sum                => Sum two top elements from stack and push result
-    sub                => Sub two top elements from stack and push result
-    mul                => Mul two top elements from stack and push result
-    div                => Div two top elements from stack and push result
-    mod                => Mod two top elements from stack and push result
-    eq                 => Check if two top elements in stack are equal and push boolean result
-    lt                 => Check if top element is lower than element under it and push boolean result
-    gt                 => Check if top element is greater than element under it and push boolean result
-    lte                => Check if top element is lower or equal than element under it and push boolean result
-    gte                => Check if top element is greater or equal than element under it and push boolean result
-    or                 => Check if one of two top elements in stack is boolean true and push boolean result
-    and                => Check if two top elements in stack are boolean true and push boolean result
-    rev                => Reverse boolean value in top of the stack
-    jmp value          => Jump to line
-    jmpif value        => Jump to line if there is boolean true in top of the stack
-    stop               => Stop execution
+    <===Types===>
+    01  int
+    02  str
+    03  bool
+    <===Types===>
+
+    <===Commands===>
+    10  begin "name"       => Begin of function
+    11  push value         => Push value to stack
+    12  pop                => Pop value from stack
+    13  var type, "name"   => Declare variable
+    14  set "name"         => Set value from top of the stack to variable
+    15  sum                => Sum two top elements from stack and push result
+    16  sub                => Sub two top elements from stack and push result
+    17  mul                => Mul two top elements from stack and push result
+    18  div                => Div two top elements from stack and push result
+    19  mod                => Mod two top elements from stack and push result
+    1a  eq                 => Check if two top elements in stack are equal and push boolean result
+    1b  neq                => Check if two top elements in stack are not equal and push boolean result
+    1c  lt                 => Check if top element is lower than element under it and push boolean result
+    1d  gt                 => Check if top element is greater than element under it and push boolean result
+    1e  lte                => Check if top element is lower or equal than element under it and push boolean result
+    1f  gte                => Check if top element is greater or equal than element under it and push boolean result
+    20  or                 => Check if one of two top elements in stack is boolean true and push boolean result
+    21  and                => Check if two top elements in stack are boolean true and push boolean result
+    22  rev                => Reverse boolean value in top of the stack
+    23  jmp value          => Jump to line
+    24  jmpif value        => Jump to line if there is boolean false in top of the stack
+    25  stop               => Stop execution
+    <===Commands===>
 
     */
 

--- a/node/pvm/vm.js
+++ b/node/pvm/vm.js
@@ -8,77 +8,86 @@ class VM {
     <===Types===>
 
     <===Commands===>
-    10  begin "name"       => Begin of function
-    11  push value         => Push value to stack
-    12  pop                => Pop value from stack
-    13  var type, "name"   => Declare variable
-    14  set "name"         => Set value from top of the stack to variable
-    15  sum                => Sum two top elements from stack and push result
-    16  sub                => Sub two top elements from stack and push result
-    17  mul                => Mul two top elements from stack and push result
-    18  div                => Div two top elements from stack and push result
-    19  mod                => Mod two top elements from stack and push result
-    1a  eq                 => Check if two top elements in stack are equal and push boolean result
-    1b  neq                => Check if two top elements in stack are not equal and push boolean result
-    1c  lt                 => Check if top element is lower than element under it and push boolean result
-    1d  gt                 => Check if top element is greater than element under it and push boolean result
-    1e  lte                => Check if top element is lower or equal than element under it and push boolean result
-    1f  gte                => Check if top element is greater or equal than element under it and push boolean result
-    20  or                 => Check if one of two top elements in stack is boolean true and push boolean result
-    21  and                => Check if two top elements in stack are boolean true and push boolean result
-    22  rev                => Reverse boolean value in top of the stack
-    23  jmp value          => Jump to line
-    24  jmpif value        => Jump to line if there is boolean false in top of the stack
-    25  stop               => Stop execution
+    10  begin "name"         => Begin of function
+    11  push 1/2 value/name  => Push value to stack
+    12  pop                  => Pop value from stack
+    13  var type, "name"     => Declare variable
+    14  set "name"           => Set value from top of the stack to variable
+    15  sum                  => Sum two top elements from stack and push result
+    16  sub                  => Sub two top elements from stack and push result
+    17  mul                  => Mul two top elements from stack and push result
+    18  div                  => Div two top elements from stack and push result
+    19  mod                  => Mod two top elements from stack and push result
+    1a  eq                   => Check if two top elements in stack are equal and push boolean result
+    1b  neq                  => Check if two top elements in stack are not equal and push boolean result
+    1c  lt                   => Check if top element is lower than element under it and push boolean result
+    1d  gt                   => Check if top element is greater than element under it and push boolean result
+    1e  lte                  => Check if top element is lower or equal than element under it and push boolean result
+    1f  gte                  => Check if top element is greater or equal than element under it and push boolean result
+    20  or                   => Check if one of two top elements in stack is boolean true and push boolean result
+    21  and                  => Check if two top elements in stack are boolean true and push boolean result
+    22  rev                  => Reverse boolean value in top of the stack
+    23  jmp value            => Jump to line
+    24  jmpif value          => Jump to line if there is boolean false in top of the stack
+    25  stop                 => Stop execution
     <===Commands===>
 
     */
 
     constructor (code) {
-        let lines = []
-        let lastIndex = 0
+        let calls = []
 
         while (code) {
-            //console.log(code)
-            code = code.trimLeft()
-            let index = code.indexOf(';')
-            let index2 = code.indexOf(' ')
-            if (index2 < index && index2 != -1) index = index2
-            let text = code.slice(0, index)
+            let call = [parseInt(code.slice(0, 2), 16)]
+            let ln
 
-            if (text == '') break
-
-            let prevIndex = index + 1
-
-            lines.push([text])
-            lastIndex = lines.length - 1
-
-            if (['push', 'set', 'begin', 'jmp', 'jmpif'].includes(text)) {
+            if ([16, 20, 35, 36].includes(call[0])) {
                 // 1 args
-                index = code.indexOf(';')
-                text = code.slice(prevIndex, index)
-                if (!isNaN(text)) text = +text
-                lines[lastIndex].push(text)
+                ln = parseInt(code.slice(2, 4), 16)
+                if (call[0] == 16 || call[0] == 20) {
+                    // arg is string
+                    let s = code.slice(4, 4 + ln)
+                    let bytes = [...s.matchAll(/[^ ]{1,2}/g)].map(a => parseInt(a[0], 16))
+                    call.push(Buffer.from(bytes).toString())
+                }
+                else {
+                    // arg is not string
+                    call.push(parseInt(code.slice(4, 4 + ln), 16))
+                }
+                code = code.slice(4 + ln)
             }
-            else if (text == 'var') {
+            else if ([17, 19].includes(call[0])) {
                 // 2 args
-                index = code.indexOf(', ')
-                text = code.slice(prevIndex, index)
-                prevIndex = index + 2
-                lines[lastIndex].push(text)
-                index = code.indexOf(';')
-                text = code.slice(prevIndex, index)
-                lines[lastIndex].push(text)
+                console.log(code.slice(0, 10))
+                call.push(parseInt(code.slice(2, 4), 16))
+                let ln = parseInt(code.slice(4, 6), 16)
+                let s = code.slice(6, 6 + ln)
+                if (call[0] == 19 || call[1] == 2) {
+                    // arg is string
+                    console.log(s)
+                    let bytes = [...s.matchAll(/[^ ]{1,2}/g)].map(a => parseInt(a[0], 16))
+                    console.log(bytes)
+                    call.push(Buffer.from(bytes).toString())
+                }
+                else {
+                    // arg is not string
+                    call.push(parseInt(s, 16))
+                }
+                code = code.slice(6 + ln)
             }
-
-            code = code.slice(index + 1)
+            else {
+                // 0 args
+                code = code.slice(2)
+            }
+            calls.push(call)
         }
 
         this.stack = []
-        this.lines = lines
+        this.calls = calls
         this.index = -1
-        for (let i = 0; i < this.lines.length; i += 1) {
-            if (this.lines[i][0] == 'begin' && this.lines[i][1] == '""') {
+        console.log(calls)
+        for (let i = 0; i < this.calls.length; i += 1) {
+            if (this.calls[i][0] == 16 && this.calls[i][1] == '\x00') {
                 this.index = i + 1
                 break
             }
@@ -91,127 +100,131 @@ class VM {
     }
 
     runNextLine () {
-        let line = this.lines[this.index]
+        let line = this.calls[this.index]
 
-        if (line[0] == 'push') {
-            if (isNaN(line[1])) {
-                if (line[1][0] == '"') this.stack.push(line[1].slice(1, -1))
-                else this.stack.push(this.variables[line[1]][1])
-            }
-            else this.stack.push(line[1])
+        console.log(line)
+
+        if (line[0] == 17) {
+            if (line[1] == 1) this.stack.push(line[2])
+            else this.stack.push(this.variables[line[2]][1])
             this.usedGas += 1
         }
 
-        else if (line[0] == 'pop') {
+        else if (line[0] == 18) {
             this.stack.pop()
             this.usedGas += 1
         }
 
-        else if (line[0] == 'var') {
+        else if (line[0] == 19) {
             this.variables[line[2]] = [line[1], undefined]
             this.usedGas += 2
         }
 
-        else if (line[0] == 'set') {
+        else if (line[0] == 20) {
             this.variables[line[1]][1] = this.stack.pop()
             this.usedGas += 2
         }
 
-        else if (line[0] == 'sum') {
+        else if (line[0] == 21) {
             this.stack.push(this.stack.pop() + this.stack.pop())
             this.usedGas += 4
         }
 
-        else if (line[0] == 'sub') {
+        else if (line[0] == 22) {
             this.stack.push(this.stack.pop() - this.stack.pop())
             this.usedGas += 4
         }
 
-        else if (line[0] == 'mul') {
+        else if (line[0] == 23) {
             this.stack.push(this.stack.pop() * this.stack.pop())
             this.usedGas += 5
         }
 
-        else if (line[0] == 'div') {
+        else if (line[0] == 24) {
             this.stack.push(this.stack.pop() / this.stack.pop())
             this.usedGas += 5
         }
 
-        else if (line[0] == 'mod') {
+        else if (line[0] == 25) {
             this.stack.push(this.stack.pop() % this.stack.pop())
             this.usedGas += 5
         }
 
-        else if (line[0] == 'eq') {
+        else if (line[0] == 26) {
             this.stack.push(this.stack.pop() == this.stack.pop())
             this.usedGas += 4
         }
 
-        else if (line[0] == 'lt') {
+        else if (line[0] == 27) {
+            this.stack.push(this.stack.pop() != this.stack.pop())
+            this.usedGas += 4
+        }
+
+        else if (line[0] == 28) {
             this.stack.push(this.stack.pop() < this.stack.pop())
             this.usedGas += 4
         }
 
-        else if (line[0] == 'gt') {
+        else if (line[0] == 29) {
             this.stack.push(this.stack.pop() > this.stack.pop())
             this.usedGas += 4
         }
 
-        else if (line[0] == 'lte') {
+        else if (line[0] == 30) {
             this.stack.push(this.stack.pop() <= this.stack.pop())
             this.usedGas += 5
         }
 
-        else if (line[0] == 'gte') {
+        else if (line[0] == 31) {
             this.stack.push(this.stack.pop() >= this.stack.pop())
             this.usedGas += 5
         }
 
-        else if (line[0] == 'or') {
+        else if (line[0] == 32) {
             let a = this.stack.pop()
             this.stack.push(this.stack.pop() || a)
             this.usedGas += 4
         }
 
-        else if (line[0] == 'and') {
+        else if (line[0] == 33) {
             let a = this.stack.pop()
             this.stack.push(this.stack.pop() && a)
             this.usedGas += 4
         }
 
-        else if (line[0] == 'rev') {
+        else if (line[0] == 34) {
             this.stack.push(!this.stack.pop())
             this.usedGas += 3
         }
 
-        else if (line[0] == 'jmp') {
+        else if (line[0] == 35) {
             this.index = line[1] - 1  // -1 so after index += 1 it's good
             this.usedGas += 1
         }
 
-        else if (line[0] == 'jmpif') {
-            if (this.stack.pop()) {
+        else if (line[0] == 36) {
+            if (!this.stack.pop()) {
                 this.index = line[1] - 1  // -1 so after index += 1 it's good
                 this.usedGas += 3
             }
             else this.usedGas += 2
         }
 
-        else if (line[0] == 'stop') {
-            this.index = this.lines.length
+        else if (line[0] == 37) {
+            this.index = this.calls.length
         }
 
-        /*console.log('Call =>', line)
+        console.log('Call =>', line)
         console.log('Index =>', this.index)
         console.log('Stack =>', this.stack)
         console.log('Variables =>', this.variables)
-        console.log()*/
+        console.log()
 
         this.index += 1
     }
 
     run () {
-        while (this.index < this.lines.length) {
+        while (this.index < this.calls.length) {
             this.runNextLine()
         }
     }

--- a/node/pvm/vm.js
+++ b/node/pvm/vm.js
@@ -211,6 +211,10 @@ class VM {
 const min = Math.min
 const fs = require('fs')
 code = fs.readFileSync(process.argv[2], 'utf8')
+console.time('prepare')
 vm = new VM(code.toString())
+console.timeEnd('prepare')
+console.time('run')
 vm.run()
-console.dir(vm.stack, {'maxArrayLength': null})
+console.timeEnd('run')
+if (process.argv.length <= 3) console.dir(vm.stack, {'maxArrayLength': null})


### PR DESCRIPTION
Running assembly-like code in PVM is wrong. Assembly is for people to easier understand machine code, but machine should run optimized code.
All operators like `push`, `pop`, `sum` etc now have their bytecode. List of them you can see in `pvm/vm.js` file

I did some benchmarking with simple tasks like prime test and found that new version of PVM with bytecodes works `x3-4` times faster than old assembly-like version. This is very good improvement.